### PR TITLE
VTF mime type definition. Fix #1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(qvtf)
 find_package(Qt4 REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(KDE4) # optional, only for extra .desktop file installation
+find_package(SharedMimeInfo 0.60) # optional, for MIME type installation
 
 pkg_check_modules(VTFLIB REQUIRED VTFLib)
 
@@ -49,4 +50,9 @@ else()
 
 	add_custom_target(uninstall
 		COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+endif()
+
+if(${SHAREDMIMEINFO_FOUND})
+	install(FILES vtf.xml DESTINATION ${XDG_MIME_INSTALL_DIR})
+	update_xdg_mimetypes(${XDG_MIME_INSTALL_DIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ read-only integration into Gtk+ (e.g. view VTF images in Eye of GNOME) see
 ### Dependencies
 
  * [VTFLib](https://github.com/panzi/VTFLib)
+ 
+Optional:
+
+* Developer package for kdelibs. This is **kdelibs5-dev** on Debian-like systems or **kdelibs-devel** on Fedora.
 
 ### License
 

--- a/vtf.xml
+++ b/vtf.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+	<mime-type type="image/x-vtf">
+		<comment>Valve Texture Format</comment>
+		<glob pattern="*.vtf"/>
+		<magic priority="60">
+			<match value="0x00465456" type="little32" offset="0"/>
+		</magic>
+		<alias type="image/vnd.valve.source.texture"/>
+	</mime-type>
+</mime-info>


### PR DESCRIPTION
Add mime type definition and optional dependency on SharedMimeInfo cmake module.