### PR TITLE
Add thumbnail service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,10 @@ endif()
 
 if (${ECM_FOUND})
 	install(FILES vtf.desktop DESTINATION "${KDE_INSTALL_KSERVICES5DIR}/qimageioplugins")
+	install(FILES vtfthumbnail.desktop DESTINATION ${KDE_INSTALL_KSERVICES5DIR})
 elseif(${KDE4_FOUND})
 	install(FILES vtf.desktop DESTINATION "${SERVICES_INSTALL_DIR}/qimageioplugins")
+	install(FILES vtfthumbnail.desktop DESTINATION ${SERVICES_INSTALL_DIR})
 else()
 # ---- uninstall target (KDE creates it for us) -------------------------------
 	configure_file(

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ read-only integration into Gtk+ (e.g. view VTF images in Eye of GNOME) see
 	git clone https://github.com/panzi/qvtf.git
 	mkdir qvtf/build
 	cd qvtf/build
-	cmake .. -DCMAKE_BUILD_TYPE=Release
+	cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release
 	make
 	sudo make install
 	

--- a/vtfthumbnail.desktop
+++ b/vtfthumbnail.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Service
+Name=Source Engine Textures
+X-KDE-ServiceTypes=ThumbCreator
+MimeType=image/x-vtf;
+X-KDE-Library=imagethumbnail
+CacheThumbnail=true


### PR DESCRIPTION
I noticed you have separate repo with vtf thumbnailer plugin. 
Actually thumbnails can be enabled without additional plugins, but additional .desktop file. 
Upon installing user should go to Configure Dolphin -> General -> Previews and enable Source Engine Textures (you may want to mention this way in README.md along with KIO plugin)

I also found that default kde installation (at least on Debian) does not include /usr/local as search path for kde services, so we should advise to always use /usr prefix.